### PR TITLE
Add basic CICD for Linux and Windows

### DIFF
--- a/.github/workflows/build-ydms.yml
+++ b/.github/workflows/build-ydms.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Create build out variable
         id: buildoutput
-        run: echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+        run: echo "build-output-dir=${{ github.workspace }}/build" >> "$Env:GITHUB_OUTPUT"
 
       - name: Configure CMake
         working-directory: ${{ steps.buildoutput.outputs.build-output-dir }}

--- a/.github/workflows/build-ydms.yml
+++ b/.github/workflows/build-ydms.yml
@@ -58,7 +58,7 @@ jobs:
         run: cmake --build . --config Release --target package
 
       - name: Upload artifacts
-        uses: actions/upload-artifact
+        uses: actions/upload-artifact@v4
         with:
           name: opus-windows
           path: ${{ steps.buildoutput.outputs.build-output-dir }}/*.dll

--- a/.github/workflows/build-ydms.yml
+++ b/.github/workflows/build-ydms.yml
@@ -49,6 +49,9 @@ jobs:
         id: buildoutput
         run: echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
+      - name: Install MinGW
+        run: sudo apt-get install -y mingw-w64
+
       - name: Configure CMake
         working-directory: ${{ steps.buildoutput.outputs.build-output-dir }}
         run: cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc

--- a/.github/workflows/build-ydms.yml
+++ b/.github/workflows/build-ydms.yml
@@ -64,4 +64,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: opus-windows
-          path: ${{ steps.buildoutput.outputs.build-output-dir }}/*.dll
+          path: ${{ steps.buildoutput.outputs.build-output-dir }}

--- a/.github/workflows/build-ydms.yml
+++ b/.github/workflows/build-ydms.yml
@@ -1,6 +1,6 @@
 name: YDMS Build
 
-on: [push, workflow_dispatch] # WORKFLOW DISPATCH FOR TESTING
+on: [push]
 
 jobs:
   Build-Linux:

--- a/.github/workflows/build-ydms.yml
+++ b/.github/workflows/build-ydms.yml
@@ -1,0 +1,32 @@
+name: YDMS Build
+
+on: [push, workflow_dispatch] # WORKFLOW DISPATCH FOR TESTING
+
+jobs:
+  Build-Linux:
+    name: Builds Opus for Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download models
+        run: ./autogen.sh
+
+      - name: Generate build files
+        run: |
+          mkdir build
+          echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+
+      - name: Configure CMake
+        working-directory: ${{ steps.buildoutput.outputs.build-output-dir }}
+        run: cmake ..
+
+      - name: Build Opus for Linux
+        working-directory: ${{ steps.buildoutput.outputs.build-output-dir }}
+        run: cmake --build . --config Release --target package
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: opus-linux
+          path: ${{ steps.buildoutput.outputs.build-output-dir }}

--- a/.github/workflows/build-ydms.yml
+++ b/.github/workflows/build-ydms.yml
@@ -35,12 +35,12 @@ jobs:
 
   Build-Windows:
     name: Builds Opus for Windows
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Download models
-        run: ./autogen.sh
+        run: ./autogen.bat
 
       - name: Create build directory
         run: mkdir build
@@ -49,16 +49,13 @@ jobs:
         id: buildoutput
         run: echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
-      - name: Install MinGW
-        run: sudo apt-get install -y mingw-w64
-
       - name: Configure CMake
         working-directory: ${{ steps.buildoutput.outputs.build-output-dir }}
-        run: cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc
+        run: cmake ..
 
       - name: Build Opus for Windows
         working-directory: ${{ steps.buildoutput.outputs.build-output-dir }}
-        run: cmake --build . --config Release --target package
+        run: cmake --build . --config Release
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-ydms.yml
+++ b/.github/workflows/build-ydms.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: opus-linux
-          path: ${{ steps.buildoutput.outputs.build-output-dir }}
+          path: ${{ steps.buildoutput.outputs.build-output-dir }}/**/*.so
 
   Build-Windows:
     name: Builds Opus for Windows

--- a/.github/workflows/build-ydms.yml
+++ b/.github/workflows/build-ydms.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Download models
         run: ./autogen.sh
 
-      - name: Generate build files
+      - name: Create build directory
         run: mkdir build
 
       - name: Create build out variable
@@ -32,3 +32,33 @@ jobs:
         with:
           name: opus-linux
           path: ${{ steps.buildoutput.outputs.build-output-dir }}/*.a
+
+  Build-Windows:
+    name: Builds Opus for Windows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download models
+        run: ./autogen.sh
+
+      - name: Create build directory
+        run: mkdir build
+
+      - name: Create build out variable
+        id: buildoutput
+        run: echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+
+      - name: Configure CMake
+        working-directory: ${{ steps.buildoutput.outputs.build-output-dir }}
+        run: cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc
+
+      - name: Build Opus for Windows
+        working-directory: ${{ steps.buildoutput.outputs.build-output-dir }}
+        run: cmake --build . --config Release --target package
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact
+        with:
+          name: opus-windows
+          path: ${{ steps.buildoutput.outputs.build-output-dir }}/*.dll

--- a/.github/workflows/build-ydms.yml
+++ b/.github/workflows/build-ydms.yml
@@ -31,4 +31,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: opus-linux
-          path: ${{ steps.buildoutput.outputs.build-output-dir }}
+          path: ${{ steps.buildoutput.outputs.build-output-dir }}/*.a

--- a/.github/workflows/build-ydms.yml
+++ b/.github/workflows/build-ydms.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{ steps.buildoutput.outputs.build-output-dir }}
-        run: cmake ..
+        run: cmake .. -DBUILD_SHARED_LIBS=ON
 
       - name: Build Opus for Linux
         working-directory: ${{ steps.buildoutput.outputs.build-output-dir }}
@@ -31,7 +31,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: opus-linux
-          path: ${{ steps.buildoutput.outputs.build-output-dir }}/*.a
+          path: ${{ steps.buildoutput.outputs.build-output-dir }}
 
   Build-Windows:
     name: Builds Opus for Windows
@@ -51,7 +51,7 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{ steps.buildoutput.outputs.build-output-dir }}
-        run: cmake ..
+        run: cmake .. -DBUILD_SHARED_LIBS=ON
 
       - name: Build Opus for Windows
         working-directory: ${{ steps.buildoutput.outputs.build-output-dir }}
@@ -61,4 +61,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: opus-windows
-          path: ${{ steps.buildoutput.outputs.build-output-dir }}
+          path: ${{ steps.buildoutput.outputs.build-output-dir }}/**/*.dll

--- a/.github/workflows/build-ydms.yml
+++ b/.github/workflows/build-ydms.yml
@@ -13,9 +13,11 @@ jobs:
         run: ./autogen.sh
 
       - name: Generate build files
-        run: |
-          mkdir build
-          echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+        run: mkdir build
+
+      - name: Create build out variable
+        id: buildoutput
+        run: echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
       - name: Configure CMake
         working-directory: ${{ steps.buildoutput.outputs.build-output-dir }}


### PR DESCRIPTION
Adds:
- GitHub Actions workflows to build the library for Linux and Windows

Additional comments:
- Some workflows such as the trailing space check expect a branch `opus-ng` - I would recommend disabling or removing that workflow
- Caching could also be added to speed up builds on the `Download models` step, but unsure how to achieve that efficiently at the moment without looking into it further
  - One way could be to `grep` the file hash in `autogen.sh` and retrieve the file accordingly
