### PR TITLE
Add native ARM builds

### DIFF
--- a/.github/workflows/build-ydms.yml
+++ b/.github/workflows/build-ydms.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         osver: [ubuntu-latest, ubuntu-24.04-arm]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.osver }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build-ydms.yml
+++ b/.github/workflows/build-ydms.yml
@@ -5,9 +5,20 @@ on: [push]
 jobs:
   Build-Linux:
     name: Builds Opus for Linux
+    strategy:
+      matrix:
+        osver: [ubuntu-latest, ubuntu-24.04-arm]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set dist name
+        run: |
+          if ${{ matrix.osver == 'ubuntu-24.04-arm' }}; then
+            echo "distname=opus-linux-arm" >> "$GITHUB_ENV"
+          else
+            echo "distname=opus-linux" >> "$GITHUB_ENV"
+          fi
 
       - name: Download models
         run: ./autogen.sh
@@ -30,7 +41,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: opus-linux
+          name: ${{ env.distname }}
           path: ${{ steps.buildoutput.outputs.build-output-dir }}/**/*.so
 
   Build-Windows:


### PR DESCRIPTION
This PR adds native ARM builds done through the new ARM runners.

The artifacts are published under the name `opus-linux-arm`.

As mentioned in the previous PRs, lots of build inherited from the parent project are failing, but the build-ydms workflow works.

See https://github.com/jae1911/opus-ydms/actions/runs/12826586788